### PR TITLE
Change CMake man page install location to share/man

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,5 +244,5 @@ install(FILES resources/icons/otter-browser-64.png DESTINATION /usr/share/icons/
 install(FILES resources/icons/otter-browser-128.png DESTINATION /usr/share/icons/hicolor/128x128/apps/ RENAME otter-browser.png)
 install(FILES resources/icons/otter-browser-256.png DESTINATION /usr/share/icons/hicolor/256x256/apps/ RENAME otter-browser.png)
 install(FILES otter-browser.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
-install(FILES man/otter-browser.1 DESTINATION man/man1/)
+install(FILES man/otter-browser.1 DESTINATION share/man/man1/)
 install(TARGETS otter-browser DESTINATION bin/)


### PR DESCRIPTION
/usr/man is deprecated and /usr/local/man may be deprecated. See http://refspecs.linuxfoundation.org/FHS_2.3/

http://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#FTN.AEN1530